### PR TITLE
KM-41: EAN-koodin korjaus

### DIFF
--- a/src/modules/LibraryCard/components/LibraryCard.tsx
+++ b/src/modules/LibraryCard/components/LibraryCard.tsx
@@ -1,17 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import {
-  View,
-  Text,
-  TouchableOpacity,
   Alert,
-  Image,
   AccessibilityInfo,
-  Platform
+  Platform,
+  useWindowDimensions
 } from 'react-native';
-import Barcode from 'react-native-barcode-builder';
 import {locales} from '../../../config/locales';
-import {styles} from './styles';
 import { getBrightnessLevel, setBrightnessLevel } from "@adrianso/react-native-device-brightness";
+import LibraryCardPortrait from './portrait/LibraryCardPortrait';
+import LibraryCardLandscape from './landscape/LibraryCardLandscape';
 
 interface IProps {
   cardNumber: string;
@@ -23,6 +20,8 @@ interface IProps {
 export const LibraryCard = ({cardNumber, holderName, logout, isFocused}: IProps) => {
 
   const [isTimeout, setIsTimeout] = useState(true)
+
+  const {width} = useWindowDimensions();
 
   useEffect(() => {
     AccessibilityInfo.announceForAccessibility(locales.userLoggedIn.fi);
@@ -79,47 +78,13 @@ export const LibraryCard = ({cardNumber, holderName, logout, isFocused}: IProps)
     ]);
   };
   
-  return (
-    <View 
-      style={styles.libraryCardContainer}
-      importantForAccessibility={isTimeout ? "no-hide-descendants" : "yes"}
-    >             
-          <View style={styles.libraryCard}>
-            <Text style={styles.holderName}>{holderName}</Text>
-            <View accessibilityLabel={locales.libraryBarCode.fi} accessibilityRole={'image'}>
-              <Barcode
-                text={cardNumber}
-                width={1.65}
-                height={90}
-                value={cardNumber}
-                format={'CODE39'}
-              />
-            </View>
-            <Text style={styles.libraryCardDescription} accessible accessibilityRole={'text'}>
-              {locales.libraryCardDescription.fi}
-            </Text>
-          </View>
-          <View style={styles.imageContainer}>
-              <Image
-                style={styles.libraryCardImage} 
-                accessibilityRole={'image'}
-                resizeMode={'contain'}
-                source={require('../../../assets/img/villirilli.png')}
-              />
-          </View>
-          <View style={styles.logoutContainer}>
-              <TouchableOpacity
-                accessible
-                accessibilityLabel={locales.pressLogout.fi}
-                style={styles.logoutButton}
-                accessibilityRole={'button'}
-                onPress={confirmLogout}
-                activeOpacity={0.6}>
-                <Text accessible={false} style={styles.buttonText}>
-                  {locales.logoutButton.fi}
-                </Text>
-              </TouchableOpacity>
-          </View>
-    </View>
+  return (width > 375) ? (
+    <LibraryCardPortrait
+      {...{cardNumber, confirmLogout, isTimeout, holderName}}
+    />
+  ) : (
+    <LibraryCardLandscape
+      {...{cardNumber, confirmLogout, isTimeout, holderName}}
+    />
   );
 };

--- a/src/modules/LibraryCard/components/LibraryCard.tsx
+++ b/src/modules/LibraryCard/components/LibraryCard.tsx
@@ -78,47 +78,48 @@ export const LibraryCard = ({cardNumber, holderName, logout, isFocused}: IProps)
       {text: locales.confirm.fi, onPress: () => logout()},
     ]);
   };
-
+  
   return (
     <View 
       style={styles.libraryCardContainer}
-      importantForAccessibility={isTimeout ? "no-hide-descendants" : "yes"}>    
-      <View style={styles.rotatedContainer}>
-        <View style={styles.libraryCard}>
-          <Text accessible={true} style={styles.holderName}>{holderName}</Text>
-          <View accessible={true} accessibilityLabel={locales.libraryBarCode.fi} accessibilityRole={'image'}>
-            <Barcode
-              text={cardNumber}
-              width={2.2}
-              height={90}
-              value={cardNumber}
-              format={'CODE39'}
-            />
+      importantForAccessibility={isTimeout ? "no-hide-descendants" : "yes"}
+    >             
+          <View style={styles.libraryCard}>
+            <Text style={styles.holderName}>{holderName}</Text>
+            <View accessibilityLabel={locales.libraryBarCode.fi} accessibilityRole={'image'}>
+              <Barcode
+                text={cardNumber}
+                width={1.65}
+                height={90}
+                value={cardNumber}
+                format={'CODE39'}
+              />
+            </View>
+            <Text style={styles.libraryCardDescription} accessible accessibilityRole={'text'}>
+              {locales.libraryCardDescription.fi}
+            </Text>
           </View>
-        </View>
-        <Text style={styles.libraryCardDescription} accessible accessibilityRole={'text'}>
-          {locales.libraryCardDescription.fi}
-        </Text>
-        <TouchableOpacity
-          accessible
-          accessibilityLabel={locales.pressLogout.fi}
-          style={styles.logoutButton}
-          accessibilityRole={'button'}
-          onPress={confirmLogout}
-          activeOpacity={0.6}>
-          <Text accessible={false} style={styles.buttonText}>
-            {locales.logoutButton.fi}
-          </Text>
-        </TouchableOpacity>
-      </View>
-      <View style={styles.imageContainer}>
-        <Image
-          style={styles.libraryCardImage}
-          accessibilityRole={'image'}
-          resizeMode={'contain'}
-          source={require('../../../assets/img/villirilli.png')}
-        />
-      </View>
+          <View style={styles.imageContainer}>
+              <Image
+                style={styles.libraryCardImage} 
+                accessibilityRole={'image'}
+                resizeMode={'contain'}
+                source={require('../../../assets/img/villirilli.png')}
+              />
+          </View>
+          <View style={styles.logoutContainer}>
+              <TouchableOpacity
+                accessible
+                accessibilityLabel={locales.pressLogout.fi}
+                style={styles.logoutButton}
+                accessibilityRole={'button'}
+                onPress={confirmLogout}
+                activeOpacity={0.6}>
+                <Text accessible={false} style={styles.buttonText}>
+                  {locales.logoutButton.fi}
+                </Text>
+              </TouchableOpacity>
+          </View>
     </View>
   );
 };

--- a/src/modules/LibraryCard/components/landscape/LibraryCardLandscape.tsx
+++ b/src/modules/LibraryCard/components/landscape/LibraryCardLandscape.tsx
@@ -49,7 +49,7 @@ const LibraryCardLandscape = ({cardNumber, confirmLogout, holderName, isTimeout}
           style={styles.libraryCardImage}
           accessibilityRole={'image'}
           resizeMode={'contain'}
-          source={require('../../../assets/img/villirilli.png')}
+          source={require('../../../../assets/img/villirilli.png')}
         />
       </View>
     </View>

--- a/src/modules/LibraryCard/components/landscape/LibraryCardLandscape.tsx
+++ b/src/modules/LibraryCard/components/landscape/LibraryCardLandscape.tsx
@@ -1,0 +1,59 @@
+import { Image, Text, TouchableOpacity, View } from "react-native";
+import { styles } from "./styles";
+import { locales } from "../../../../config/locales";
+import Barcode from "react-native-barcode-builder";
+
+
+interface ILandscapeProps {
+  cardNumber: string;
+  confirmLogout: () => void;
+  holderName?: string;
+  isTimeout: boolean;
+}
+
+const LibraryCardLandscape = ({cardNumber, confirmLogout, holderName, isTimeout}: ILandscapeProps) => {
+  return (
+    <View
+      style={styles.libraryCardContainer}
+      importantForAccessibility={isTimeout ? "no-hide-descendants" : "yes"}>    
+      <View style={styles.rotatedContainer}>
+        <View style={styles.libraryCard}>
+          <Text accessible={true} style={styles.holderName}>{holderName}</Text>
+          <View accessible={true} accessibilityLabel={locales.libraryBarCode.fi} accessibilityRole={'image'}>
+            <Barcode
+              text={cardNumber}
+              width={2.2}
+              height={90}
+              value={cardNumber}
+              format={'CODE39'}
+            />
+          </View>
+        </View>
+        <Text style={styles.libraryCardDescription} accessible accessibilityRole={'text'}>
+          {locales.libraryCardDescription.fi}
+        </Text>
+        <TouchableOpacity
+          accessible
+          accessibilityLabel={locales.pressLogout.fi}
+          style={styles.logoutButton}
+          accessibilityRole={'button'}
+          onPress={confirmLogout}
+          activeOpacity={0.6}>
+          <Text accessible={false} style={styles.buttonText}>
+            {locales.logoutButton.fi}
+          </Text>
+        </TouchableOpacity>
+      </View>
+      <View style={styles.imageContainer}>
+        <Image
+          style={styles.libraryCardImage}
+          accessibilityRole={'image'}
+          resizeMode={'contain'}
+          source={require('../../../assets/img/villirilli.png')}
+        />
+      </View>
+    </View>
+  )
+}
+
+export default LibraryCardLandscape;

--- a/src/modules/LibraryCard/components/landscape/styles.ts
+++ b/src/modules/LibraryCard/components/landscape/styles.ts
@@ -1,0 +1,77 @@
+import {StyleSheet, Dimensions, Platform} from 'react-native';
+
+const textFont = 'Roboto';
+
+export const styles = StyleSheet.create({
+  logoutButton: {
+    width: '45%',
+    padding: 10,
+    borderRadius: 10,
+    alignItems: 'center',
+    alignSelf: 'center',
+    backgroundColor: '#212121',
+    position: 'absolute',
+    bottom: 10,
+    left: '5%',
+  },
+  buttonText: {
+    fontFamily: textFont,
+    fontSize: 19,
+    fontWeight: 'bold',
+    color: '#fff',
+  },
+  libraryCardContainer: {
+    height: '100%',
+    alignSelf: 'center',
+    justifyContent: 'center',
+  },
+  rotatedContainer: {
+    transform: [{rotate: '90deg'}],
+    height: Dimensions.get('window').width * 0.99,
+    width: Dimensions.get('window').height * 0.9,
+    justifyContent: 'center',
+  },
+  libraryCard: {
+    marginBottom: '20%',
+  },
+  libraryCardDescription: {
+    fontFamily: textFont,
+    fontSize: 21,
+    width: '60%',
+    position: 'absolute',
+    padding: 35,
+    paddingLeft: 45,
+    top: '45%',
+  },
+  imageContainer: {
+    position: 'absolute',
+    ...Platform.select({
+      ios: {
+        left:
+          Dimensions.get('window').width > 400
+            ? Dimensions.get('window').height * 0.26
+            : Dimensions.get('window').height * 0.24,
+      },
+      android: {
+        left:
+          Dimensions.get('window').width > 410
+            ? Dimensions.get('window').height * 0.2
+            : Dimensions.get('window').height * 0.25,
+      },
+    }),
+
+    top: Dimensions.get('window').height * 0.55,
+    height: '30%',
+    width: Dimensions.get('window').width > 400 ? '35%' : '30%',
+    zIndex: -1,
+  },
+  libraryCardImage: {
+    maxWidth: '100%',
+    maxHeight: '100%',
+    transform: [{rotate: '90deg'}],
+  },
+  holderName: {
+    textAlign: 'center',
+    fontSize: 18,
+  },
+});

--- a/src/modules/LibraryCard/components/portrait/LibraryCardPortrait.tsx
+++ b/src/modules/LibraryCard/components/portrait/LibraryCardPortrait.tsx
@@ -1,0 +1,59 @@
+import { Image, Text, TouchableOpacity, View } from "react-native"
+import Barcode from "react-native-barcode-builder"
+import {locales} from '../../../../config/locales';
+import { styles } from "./styles";
+
+interface IPortraitProps {
+  cardNumber: string;
+  confirmLogout: () => void;
+  holderName?: string;
+  isTimeout: boolean;
+}
+
+const LibraryCardPortrait = ({cardNumber, confirmLogout, holderName, isTimeout}: IPortraitProps) => {
+  return (
+    <View
+      style={styles.libraryCardContainer}
+      importantForAccessibility={isTimeout ? "no-hide-descendants" : "yes"}
+    >             
+      <View style={styles.libraryCard}>
+        <Text style={styles.holderName}>{holderName}</Text>
+        <View accessibilityLabel={locales.libraryBarCode.fi} accessibilityRole={'image'}>
+          <Barcode
+            text={cardNumber}
+            width={1.65}
+            height={90}
+            value={cardNumber}
+            format={'CODE39'}
+          />
+        </View>
+        <Text style={styles.libraryCardDescription} accessible accessibilityRole={'text'}>
+          {locales.libraryCardDescription.fi}
+        </Text>
+      </View>
+      <View style={styles.imageContainer}>
+          <Image
+            style={styles.libraryCardImage} 
+            accessibilityRole={'image'}
+            resizeMode={'contain'}
+            source={require('../../../assets/img/villirilli.png')}
+          />
+      </View>
+      <View style={styles.logoutContainer}>
+          <TouchableOpacity
+            accessible
+            accessibilityLabel={locales.pressLogout.fi}
+            style={styles.logoutButton}
+            accessibilityRole={'button'}
+            onPress={confirmLogout}
+            activeOpacity={0.6}>
+            <Text accessible={false} style={styles.buttonText}>
+              {locales.logoutButton.fi}
+            </Text>
+          </TouchableOpacity>
+      </View>
+  </View>
+  )
+}
+
+export default LibraryCardPortrait;

--- a/src/modules/LibraryCard/components/portrait/LibraryCardPortrait.tsx
+++ b/src/modules/LibraryCard/components/portrait/LibraryCardPortrait.tsx
@@ -36,7 +36,7 @@ const LibraryCardPortrait = ({cardNumber, confirmLogout, holderName, isTimeout}:
             style={styles.libraryCardImage} 
             accessibilityRole={'image'}
             resizeMode={'contain'}
-            source={require('../../../assets/img/villirilli.png')}
+            source={require('../../../../assets/img/villirilli.png')}
           />
       </View>
       <View style={styles.logoutContainer}>

--- a/src/modules/LibraryCard/components/portrait/styles.ts
+++ b/src/modules/LibraryCard/components/portrait/styles.ts
@@ -1,0 +1,50 @@
+import {StyleSheet} from 'react-native';
+
+const textFont = 'Roboto';
+
+export const styles = StyleSheet.create({
+  logoutContainer: {
+    justifyContent: "center", 
+    alignItems: "center", 
+    flex: 1
+  },
+  logoutButton: {
+    height: 50,
+    padding: 10,
+    borderRadius: 10,
+    backgroundColor: '#212121',
+  },
+  buttonText: {
+    fontFamily: textFont,
+    fontSize: 19,
+    fontWeight: 'bold',
+    color: '#fff',
+  },
+  libraryCardContainer: {
+    height: '100%',
+    flex: 1
+  },
+  libraryCard: {
+    flex: 3,
+    justifyContent: "center",
+    alignItems: "center"
+  },
+  libraryCardDescription: {
+    fontFamily: textFont,
+    fontSize: 21,
+    padding: 15,
+  },
+  imageContainer: {
+    alignItems: "center", 
+    flex: 1
+  },
+  libraryCardImage: {
+    maxWidth: '100%',
+    maxHeight: '100%',
+    transform: [{rotate: '90deg'}],
+  },
+  holderName: {
+    textAlign: 'center',
+    fontSize: 18,
+  },
+});

--- a/src/modules/LibraryCard/components/styles.ts
+++ b/src/modules/LibraryCard/components/styles.ts
@@ -76,49 +76,10 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: '#212121',
   },
-  logoutContainer: {
-    justifyContent: "center", 
-    alignItems: "center", 
-    flex: 1
-  },
-  logoutButton: {
-    height: 50,
-    padding: 10,
-    borderRadius: 10,
-    backgroundColor: '#212121',
-  },
   buttonText: {
     fontFamily: textFont,
     fontSize: 19,
     fontWeight: 'bold',
     color: '#fff',
-  },
-  libraryCardContainer: {
-    height: '100%',
-    flex: 1
-  },
-  libraryCard: {
-    flex: 3,
-    justifyContent: "center",
-    alignItems: "center"
-  },
-  libraryCardDescription: {
-    fontFamily: textFont,
-    fontSize: 21,
-    padding: 15,
-  },
-  imageContainer: {
-    justifyContent: "center", 
-    alignItems: "center", 
-    flex: 1
-  },
-  libraryCardImage: {
-    maxWidth: '100%',
-    maxHeight: '100%',
-    transform: [{rotate: '90deg'}],
-  },
-  holderName: {
-    textAlign: 'center',
-    fontSize: 18,
   },
 });

--- a/src/modules/LibraryCard/components/styles.ts
+++ b/src/modules/LibraryCard/components/styles.ts
@@ -6,17 +6,6 @@ const textFont = 'Roboto';
 
 export const styles = StyleSheet.create({
   headerContainer: {marginTop: '2%', alignSelf: 'center'},
-  largeHeaderText: {
-    fontFamily: 'Times New Roman',
-    fontSize: 45,
-    textTransform: 'uppercase',
-  },
-  smallHeaderText: {
-    fontFamily: textFont,
-    fontSize: 32,
-    paddingLeft: 45,
-    letterSpacing: 2,
-  },
   loginHeaderImage: {maxWidth: '70%'},
   loginDescription: {
     width: '90%',
@@ -48,13 +37,6 @@ export const styles = StyleSheet.create({
         fontWeight: 'bold',
       },
     }),
-  },
-  loginImage: {
-    position: 'absolute',
-    top: '15%',
-    left: '5%',
-    zIndex: -1,
-    opacity: 0.5,
   },
   errorMessage: {
     color: '#EB0000',
@@ -94,17 +76,16 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: '#212121',
   },
-
+  logoutContainer: {
+    justifyContent: "center", 
+    alignItems: "center", 
+    flex: 1
+  },
   logoutButton: {
-    width: '45%',
+    height: 50,
     padding: 10,
     borderRadius: 10,
-    alignItems: 'center',
-    alignSelf: 'center',
     backgroundColor: '#212121',
-    position: 'absolute',
-    bottom: 10,
-    left: '5%',
   },
   buttonText: {
     fontFamily: textFont,
@@ -114,48 +95,22 @@ export const styles = StyleSheet.create({
   },
   libraryCardContainer: {
     height: '100%',
-    alignSelf: 'center',
-    justifyContent: 'center',
-  },
-  rotatedContainer: {
-    transform: [{rotate: '90deg'}],
-    height: Dimensions.get('window').width * 0.99,
-    width: Dimensions.get('window').height * 0.9,
-    justifyContent: 'center',
+    flex: 1
   },
   libraryCard: {
-    marginBottom: '20%',
+    flex: 3,
+    justifyContent: "center",
+    alignItems: "center"
   },
   libraryCardDescription: {
     fontFamily: textFont,
     fontSize: 21,
-    width: '60%',
-    position: 'absolute',
-    padding: 35,
-    paddingLeft: 45,
-    top: '45%',
+    padding: 15,
   },
   imageContainer: {
-    position: 'absolute',
-    ...Platform.select({
-      ios: {
-        left:
-          Dimensions.get('window').width > 400
-            ? Dimensions.get('window').height * 0.26
-            : Dimensions.get('window').height * 0.24,
-      },
-      android: {
-        left:
-          Dimensions.get('window').width > 410
-            ? Dimensions.get('window').height * 0.2
-            : Dimensions.get('window').height * 0.25,
-      },
-    }),
-
-    top: Dimensions.get('window').height * 0.55,
-    height: '30%',
-    width: Dimensions.get('window').width > 400 ? '35%' : '30%',
-    zIndex: -1,
+    justifyContent: "center", 
+    alignItems: "center", 
+    flex: 1
   },
   libraryCardImage: {
     maxWidth: '100%',


### PR DESCRIPTION
- updated library card screen to be in portrait mode, improved some styling
- made ean code smaller
- use old landscape version if device screen width is too small to show ean in portrait mode

to test:
- in the KouvolaCityApp project, update `library-card-module` path: ` "library_card_module": "github:City-of-Kouvola/Library_card_module#KM-41-EAN-koodin-korjaus",`
- remove `node_modules` folder and `package-lock.json` file
- clear npm cache: `sudo npm cache clean --force && npm cache verify`
- install new packages: `npm install`