### PR TITLE
KM-50/reset-brightness-after-library-card-screen

### DIFF
--- a/src/modules/LibraryCard/components/LibraryCard.tsx
+++ b/src/modules/LibraryCard/components/LibraryCard.tsx
@@ -33,6 +33,7 @@ export const LibraryCard = ({cardNumber, holderName, logout, isFocused}: IProps)
   useEffect(() => {
 
     if (!isFocused) {
+      setBrightnessLevel(-1);
       return;
     }
 

--- a/src/modules/LibraryCard/components/LibraryCard.tsx
+++ b/src/modules/LibraryCard/components/LibraryCard.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   Alert,
   AccessibilityInfo,
   Platform,
-  useWindowDimensions
+  useWindowDimensions,
+  AppState,
+  NativeEventSubscription,
 } from 'react-native';
 import {locales} from '../../../config/locales';
 import { getBrightnessLevel, setBrightnessLevel } from "@adrianso/react-native-device-brightness";
@@ -13,29 +15,84 @@ import LibraryCardLandscape from './landscape/LibraryCardLandscape';
 interface IProps {
   cardNumber: string;
   holderName?: string;
-  logout: () => void;
+  logout: (resetBrightness: () => void) => void;
   isFocused?: boolean;
 }
 
 export const LibraryCard = ({cardNumber, holderName, logout, isFocused}: IProps) => {
-
+  
   const [isTimeout, setIsTimeout] = useState(true)
+  const [oldBrightness, setOldBrightness] = useState<number>(1);
 
+  const appState = useRef(AppState.currentState);
+  const listener: React.MutableRefObject<NativeEventSubscription | null> = useRef(null);
+  
   const {width} = useWindowDimensions();
 
   useEffect(() => {
+
     AccessibilityInfo.announceForAccessibility(locales.userLoggedIn.fi);
     setTimeout(() => {
       setIsTimeout(false)
     }, 5000);
-  }, [])  
+
+  }, [])
+
+  useEffect(() => {
+
+    if (Platform.OS === "android") {
+      // android can handle the brightness on app state change automatically because it has separate app brightness and system brightness, 
+      // therefore it does not require the app state listeners like ios does
+      return;
+    }
+
+    if (!isFocused) {
+      resetBrightness();
+      return;
+    }
+
+    
+    listener.current = AppState.addEventListener('change', (nextAppState) => {
+
+      if (
+        appState.current.match(/active/) &&
+        nextAppState === 'background' || nextAppState === 'inactive'
+      ) {
+        setBrightnessLevel(oldBrightness);
+      } else if (
+        appState.current.match(/inactive|background/) &&
+        nextAppState === 'active'
+      ) {
+        setBrightnessLevel(1);
+      }
+  
+      appState.current = nextAppState;
+
+    });
+
+    return () => {
+      resetBrightness();
+    };
+
+  }, [isFocused, oldBrightness]);
+
+  const resetBrightness = () => {
+    if (listener.current) {
+      listener.current.remove()
+    }
+    setBrightnessLevel(oldBrightness); 
+  }
 
   useEffect(() => {
 
     if (!isFocused) {
-      setBrightnessLevel(-1);
+      resetBrightness();
       return;
     }
+
+    getBrightnessLevel().then(brightness => {
+      setOldBrightness(brightness);
+    });
 
     if (Platform.OS === "android") {
 
@@ -67,7 +124,7 @@ export const LibraryCard = ({cardNumber, holderName, logout, isFocused}: IProps)
 
     };
 
-  }, [isFocused]);
+  }, [isFocused, listener]);
 
   const confirmLogout = () => {
     Alert.alert(locales.confirmLogout.fi, '', [
@@ -75,7 +132,7 @@ export const LibraryCard = ({cardNumber, holderName, logout, isFocused}: IProps)
         text: locales.cancel.fi,
         style: 'cancel',
       },
-      {text: locales.confirm.fi, onPress: () => logout()},
+      {text: locales.confirm.fi, onPress: () => logout(resetBrightness)},
     ]);
   };
   

--- a/src/modules/LibraryCard/index.tsx
+++ b/src/modules/LibraryCard/index.tsx
@@ -1,9 +1,8 @@
 import React, {useState, useEffect} from 'react';
-import {View, Text, AccessibilityInfo,} from 'react-native';
+import {AccessibilityInfo} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {LibraryCard, Login} from './components';
 import {locales} from '../../config/locales';
-import { setBrightnessLevel } from '@adrianso/react-native-device-brightness';
 
 export const LibraryCardModule = ({isFocused}: {isFocused?: boolean}) => {
   const [cardNumber, setCardNumber] = useState<string>('');
@@ -41,10 +40,10 @@ export const LibraryCardModule = ({isFocused}: {isFocused?: boolean}) => {
     }
   };
 
-  const logout = async () => {
+  const logout = async (resetBrightness: () => void) => {
     try {
       await AsyncStorage.multiRemove(['@cardNumber', '@holderName']);
-      await setBrightnessLevel(-1);
+      resetBrightness();
       setCardNumber('');
       setHolderName('');
       AccessibilityInfo.announceForAccessibility(locales.userLoggedOut.fi);
@@ -61,7 +60,7 @@ export const LibraryCardModule = ({isFocused}: {isFocused?: boolean}) => {
 
   if (cardNumber) {
     return (
-      <LibraryCard isFocused={isFocused} logout={() => logout()} {...{cardNumber, holderName}} />
+      <LibraryCard isFocused={isFocused} logout={logout} {...{cardNumber, holderName}} />
     );
   }
   if (isLoading) return <></>;

--- a/src/modules/LibraryCard/index.tsx
+++ b/src/modules/LibraryCard/index.tsx
@@ -3,6 +3,7 @@ import {View, Text, AccessibilityInfo,} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {LibraryCard, Login} from './components';
 import {locales} from '../../config/locales';
+import { setBrightnessLevel } from '@adrianso/react-native-device-brightness';
 
 export const LibraryCardModule = ({isFocused}: {isFocused?: boolean}) => {
   const [cardNumber, setCardNumber] = useState<string>('');
@@ -43,6 +44,7 @@ export const LibraryCardModule = ({isFocused}: {isFocused?: boolean}) => {
   const logout = async () => {
     try {
       await AsyncStorage.multiRemove(['@cardNumber', '@holderName']);
+      await setBrightnessLevel(-1);
       setCardNumber('');
       setHolderName('');
       AccessibilityInfo.announceForAccessibility(locales.userLoggedOut.fi);


### PR DESCRIPTION
- added "oldBrightness" state that stores the brightness before it is being made 100% in the library card screen. this value is then made the new brightness after leaving the screen or app.
- on ios, added a listener that resets the brightness when the app screen is exited. on android, this is done automatically since it handles app brightness and system brightness separately
- the listener is handled from a ref to ensure that no more than one listener is running at once